### PR TITLE
Add context to urllib request

### DIFF
--- a/pytfc/state_versions.py
+++ b/pytfc/state_versions.py
@@ -133,23 +133,23 @@ class StateVersions(object):
         return sv.json()\
             ['data']['attributes']['hosted-json-state-download-url']
     
-    def download(self, url):
+    def download(self, url, context=None):
         """
         Utility method to download a State Version
         based on the download URL that is specified.
         Returns raw state object in bytes.
         """
-        state_dl = request.urlopen(url=url, data=None)
+        state_dl = request.urlopen(url=url, data=None, context=context)
         state_obj = state_dl.read()
         return state_obj
     
-    def download_current(self):
+    def download_current(self, context=None):
         """
         Utility method to download the current
         State Version of the Workspace.
         Returns raw state object in bytes.
         """
         url = self._get_download_url()
-        state_dl = request.urlopen(url=url, data=None)
+        state_dl = request.urlopen(url=url, data=None, context=context)
         state_obj = state_dl.read()
         return state_obj

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()


### PR DESCRIPTION
- add `context` argument to request.urlopen() method to download state file