### PR TITLE
Add header arg to State Version download

### DIFF
--- a/pytfc/state_versions.py
+++ b/pytfc/state_versions.py
@@ -133,23 +133,25 @@ class StateVersions(object):
         return sv.json()\
             ['data']['attributes']['hosted-json-state-download-url']
     
-    def download(self, url, context=None):
+    def download(self, url, context=None, headers={}):
         """
         Utility method to download a State Version
         based on the download URL that is specified.
         Returns raw state object in bytes.
         """
-        state_dl = request.urlopen(url=url, data=None, context=context)
+        state_dl_req = request.Request(url=url, headers=headers, data=None)
+        state_dl = request.urlopen(state_dl_req, context=context)
         state_obj = state_dl.read()
         return state_obj
     
-    def download_current(self, context=None):
+    def download_current(self, context=None, headers={}):
         """
         Utility method to download the current
         State Version of the Workspace.
         Returns raw state object in bytes.
         """
         url = self._get_download_url()
-        state_dl = request.urlopen(url=url, data=None, context=context)
+        state_dl_req = request.Request(url=url, headers=headers, data=None)
+        state_dl = request.urlopen(state_dl_req, context=context)
         state_obj = state_dl.read()
         return state_obj

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = '0.0.5'
+VERSION = '0.0.6'
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
@@ -11,22 +11,23 @@ setup(
     version=VERSION,
     author='Alex Basista',
     author_email='alex.basista@gmail.com',
+    url='https://github.com/alexbasista/pytfc',
     description='Python HTTP client library for Terraform Cloud/Enterprise API.',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    url='https://github.com/alexbasista/pytfc',
-    py_modules=["pytfc"],
+    long_description_content_type='text/markdown',
+    license_files=['LICENSE'],
+    py_modules=['pytfc'],
     packages=find_packages(),
     install_requires=[
-        "pyhcl>=0.4.4",
-        "requests>=2.26.0",
+        'pyhcl>=0.4.4',
+        'requests>=2.26.0',
     ],
     keywords=['tfe', 'terraform enterprise', 'tfc', 'terraform cloud', 'terraform'],
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        "Operating System :: OS Independent",
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
+        'Operating System :: OS Independent',
     ],
 )


### PR DESCRIPTION
CloudFlare does not like `urllib.requests` and was throwing 403 forbidden errors when attempting to download a State Version from a TFE instance sitting behind CloudFlare.  This update adds a `header` argument to the request so we can pass something like `{'User-Agent': 'Mozilla/5.0'}` in as a header to get by the 403's.