### PR TITLE
Fix ws vcs payload

### DIFF
--- a/pytfc/api/workspace_variables.py
+++ b/pytfc/api/workspace_variables.py
@@ -60,21 +60,6 @@ class WorkspaceVariables(TfcApiBase):
 
         path = f'/workspaces/{ws_id}/vars'
         return self._requestor.get(path=path)
-    
-    @validate_ws_id_is_set
-    def list_all(self, ws_id=None):
-        """
-        GET /workspaces/:workspace_id/vars
-
-        Built-in logic to enumerate all pages in list response for
-        cases where there are more than 100 Workspace Variables.
-
-        Returns object (dict) with two arrays: `data` and `included`.
-        """
-        ws_id = ws_id if ws_id else self.ws_id
-        
-        path = f'/workspaces/{ws_id}/vars'
-        return self._requestor.list_all(path=path)
 
     def update(self, var_name=None, var_id=None, ws_id=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = '0.0.16'
+VERSION = '0.0.17'
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()


### PR DESCRIPTION
- Replace underscores with hyphens for the VCS-related attributes within the VCS object of the Workspace create and Workspace update method payloads
- Simplify Workspace creation method by removing overly-ambitious logic to support different scenarios of OAuth Clients that while cool to have, probably wouldn't have been used much and would enable bad habits for users
- Remove unneeded method of list_all() from Workspace Variables class because Workspace Variables endpoint doesn't use pagination