### PR TITLE
update publish step for test pypi

### DIFF
--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package
+    - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_PYTFC_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Fixing syntax argument error for the `Test PyPI Release` action.

Specifically, `repository_url` needed an underscore instead of a hyphen.

