### PR TITLE
Update GHA workflows and release process

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PYTFC_API_TOKEN }}
+    # - name: Publish package to PyPI
+    #   uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_PYTFC_API_TOKEN }}

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,8 +1,8 @@
 name: PyPI Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: [ 'v*.*.*' ]
 
 permissions:
   contents: read
@@ -25,10 +25,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
 
+    - name: Set package version from tag
+      run: |
+        echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+        sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
+
     - name: Build package
       run: python -m build
 
-    - name: Publish package
+    - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -2,7 +2,7 @@ name: PyPI Release
 
 on:
   push:
-    tags: [ 'v*.*.*' ]
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 
 permissions:
   contents: read

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Build package
       run: python -m build
 
-    # - name: Publish package to PyPI
-    #   uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_PYTFC_API_TOKEN }}
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PYTFC_API_TOKEN }}

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -19,12 +19,12 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
-        cache-dependency-path: '**/requirements-dev.txt'
+        cache-dependency-path: '**/setup.py'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        pip install .[dev]
 
     - name: Run pytest
       run: |
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install .[dev]
       
       - name: Bump version
         run: |

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -44,21 +44,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       
-      - name: Tag check
-        id: tagCheck
-        run: |
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-test$ ]]; then
-            echo "{isTag}={true}" >> $GITHUB_OUTPUT
-          else
-            echo "{isTag}={false}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set version from tag
-        if: steps.tagCheck.outputs.isTag == 'true'
-        run: |
-          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
-          sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
-      
       - name: Set version from run number
         run: |
           VERSION_PREFIX="v0.0."

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -18,8 +18,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -48,9 +48,9 @@ jobs:
         id: tagCheck
         run: |
           if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::set-output name=isTag::true"
+            echo "{isTag}={true}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=isTag::false"
+            echo "{isTag}={false}" >> $GITHUB_OUTPUT
           fi
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Set version from run number
         run: |
           VERSION_PREFIX="v0.0."
-          NEW_VERSION="$VERSION_PREFIX${{ github.run_number }}"
+          VERSION_SUFFIX="${{ github.run_number }}"
+          NEW_VERSION="$VERSION_PREFIX$VERSION_SUFFIX"
           echo "New version: $NEW_VERSION"
           sed -i "s/VERSION = 'TAG'/VERSION = '$NEW_VERSION'/" setup.py
 

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -48,19 +48,19 @@ jobs:
         id: tagCheck
         run: |
           if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-test$ ]]; then
-            echo "{is_tag}={true}" >> $GITHUB_OUTPUT
+            echo "{isTag}={true}" >> $GITHUB_OUTPUT
           else
-            echo "{is_tag}={false}" >> $GITHUB_OUTPUT
+            echo "{isTag}={false}" >> $GITHUB_OUTPUT
           fi
 
       - name: Set version from tag
-        if: steps.tagCheck.outputs.is_tag == 'true'
+        if: steps.tagCheck.outputs.isTag == 'true'
         run: |
           echo "Tag name from github.ref_name: ${{  github.ref_name }}"
           sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
       
       - name: Set version from run number
-        if: steps.tagCheck.outputs.is_tag == 'false'
+        if: steps.tagCheck.outputs.isTag == 'false'
         run: |
           VERSION_PREFIX="v0.0."
           NEW_VERSION="$VERSION_PREFIX${{ github.run_number }}"

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -45,7 +45,7 @@ jobs:
           pip install -r requirements-dev.txt
       
       - name: Tag check
-        id: tag_check
+        id: tagCheck
         run: |
           if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-test$ ]]; then
             echo "{is_tag}={true}" >> $GITHUB_OUTPUT
@@ -54,13 +54,13 @@ jobs:
           fi
 
       - name: Set version from tag
-        if: steps.tag_check.outputs.is_tag == 'true'
+        if: steps.tagCheck.outputs.is_tag == 'true'
         run: |
           echo "Tag name from github.ref_name: ${{  github.ref_name }}"
           sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
       
       - name: Set version from run number
-        if: steps.tag_check.outputs.is_tag == 'false'
+        if: steps.tagCheck.outputs.is_tag == 'false'
         run: |
           VERSION_PREFIX="v0.0."
           NEW_VERSION="$VERSION_PREFIX${{ github.run_number }}"

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           VERSION_PREFIX="v0.0."
           NEW_VERSION="$VERSION_PREFIX${{ github.run_number }}"
-          echo "$NEW_VERSION"
+          echo "New version: $NEW_VERSION"
           sed -i "s/VERSION = 'TAG'/VERSION = '$NEW_VERSION'/" setup.py
 
       - name: Build package

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev]
+        #pip install .[dev]
+        pip install -r requirements-dev.txt
 
     - name: Run pytest
       run: |
@@ -42,7 +43,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          #pip install .[dev]
+          pip install -r requirements-dev.txt
       
       - name: Bump version
         run: |

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -63,9 +63,11 @@ jobs:
           sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
       
       - name: Build package
+        if: steps.tagCheck.outputs.isTag == 'true'  
         run: python -m build
     
       - name: Publish package to TestPyPI
+        if: steps.tagCheck.outputs.isTag == 'true'  
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -60,7 +60,6 @@ jobs:
           sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
       
       - name: Set version from run number
-        if: steps.tagCheck.outputs.isTag == 'false'
         run: |
           VERSION_PREFIX="v0.0."
           NEW_VERSION="$VERSION_PREFIX${{ github.run_number }}"

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.x'
 
     - name: Install dependencies
       run: |
@@ -45,29 +45,32 @@ jobs:
           pip install -r requirements-dev.txt
       
       - name: Tag check
-        id: tagCheck
+        id: tag_check
         run: |
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "{isTag}={true}" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-test$ ]]; then
+            echo "{is_tag}={true}" >> $GITHUB_OUTPUT
           else
-            echo "{isTag}={false}" >> $GITHUB_OUTPUT
+            echo "{is_tag}={false}" >> $GITHUB_OUTPUT
           fi
-        env:
-          GITHUB_REF_NAME: ${{ github.ref_name }}
 
-      - name: Set version
-        if: steps.tagCheck.outputs.isTag == 'true'
+      - name: Set version from tag
+        if: steps.tag_check.outputs.is_tag == 'true'
         run: |
-          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
           echo "Tag name from github.ref_name: ${{  github.ref_name }}"
           sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
       
+      - name: Set version from run number
+        if: steps.tag_check.outputs.is_tag == 'false'
+        run: |
+          VERSION_PREFIX="v0.0."
+          NEW_VERSION="$VERSION_PREFIX${{ github.run_number }}"
+          echo "$NEW_VERSION"
+          sed -i "s/VERSION = 'TAG'/VERSION = '$NEW_VERSION'/" setup.py
+
       - name: Build package
-        if: steps.tagCheck.outputs.isTag == 'true'  
         run: python -m build
     
       - name: Publish package to TestPyPI
-        if: steps.tagCheck.outputs.isTag == 'true'  
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -22,7 +22,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        #pip install .[dev]
         pip install -r requirements-dev.txt
 
     - name: Run pytest
@@ -43,10 +42,21 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          #pip install .[dev]
           pip install -r requirements-dev.txt
       
-      - name: Bump version
+      - name: Tag check
+        id: tagCheck
+        run: |
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::set-output name=isTag::true"
+          else
+            echo "::set-output name=isTag::false"
+          fi
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      - name: Set version
+        if: steps.tagCheck.outputs.isTag == 'true'
         run: |
           echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
           echo "Tag name from github.ref_name: ${{  github.ref_name }}"

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -46,6 +46,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       
+      - name: Bump version
+        run: |
+          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+          sed -i "s/VERSION = 'TAG'/VERSION = '${{ github.ref_name }}'/" setup.py
+      
       - name: Build package
         run: python -m build
     

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = 'TAG'
+VERSION = 'TAG' # value is updated by release pipeline
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = '0.0.21'
+VERSION = 'TAG'
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
@@ -22,6 +22,9 @@ setup(
         'requests>=2.31.0',
         'pyhcl>=0.4.4',
     ],
+    extras_require={
+        'dev': ['build==1.0.3', 'pytest==7.4.2'],
+    },
     keywords=['tfe', 'terraform enterprise', 'tfc', 'terraform cloud', 'terraform'],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- Improve and simplify `Test PyPI CI` workflow.
- Update release strategy to PyPI (`PyPI Release` workflow`) by changing the trigger to run when a tag is created following semantic versioning (`'v[0-9]+.[0-9]+.[0-9]+'`).  The workflow will dynamically set the package version based on the tag/release that triggered the workflow, so the version is no longer hardcoded in `setup.py`.  The git tags are now the source of truth for versioning.